### PR TITLE
Add basic number visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # d3_regrouping_exchanging
 
-a d3 app that illustrates the concept of regrouping and exchanging for primary maths
+A simple D3 application to visualise regrouping and exchanging.
+
+Open `index.html` in a browser and enter a number (0-9999) to see it represented as columns for thousands, hundreds, tens and ones.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Regrouping Visualizer</title>
+  <link rel="stylesheet" href="styles.css">
+  <script src="https://d3js.org/d3.v7.min.js"></script>
+  <script type="module" src="js/main.js" defer></script>
+</head>
+<body>
+  <div id="controls">
+    <input id="number-input" type="number" min="0" max="9999" placeholder="Enter number" />
+  </div>
+  <div id="visualization"></div>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,11 @@
+import { createSvg } from './svgSetup.js';
+import { update } from './updateVisualization.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const { g, columnWidth, height } = createSvg('#visualization');
+  const input = document.getElementById('number-input');
+  const updateViz = () => update(g, columnWidth, height, input.value);
+
+  input.addEventListener('input', updateViz);
+  updateViz();
+});

--- a/js/svgSetup.js
+++ b/js/svgSetup.js
@@ -1,0 +1,29 @@
+const width = 300;
+const height = 200;
+const margin = { top: 20, right: 20, bottom: 40, left: 20 };
+
+export function createSvg(container) {
+  const svg = d3
+    .select(container)
+    .append('svg')
+    .attr('width', width)
+    .attr('height', height);
+
+  const g = svg
+    .append('g')
+    .attr('transform', `translate(${margin.left}, ${margin.top})`);
+
+  const labels = ['thousands', 'hundreds', 'tens', 'ones'];
+  const columnWidth = (width - margin.left - margin.right) / labels.length;
+
+  labels.forEach((label, i) => {
+    const x = i * columnWidth;
+    g.append('text')
+      .attr('x', x + columnWidth / 2)
+      .attr('y', height - margin.bottom + 15)
+      .attr('text-anchor', 'middle')
+      .text(label);
+  });
+
+  return { svg, g, columnWidth, height: height - margin.bottom };
+}

--- a/js/updateVisualization.js
+++ b/js/updateVisualization.js
@@ -1,0 +1,21 @@
+import { splitNumber } from './utils.js';
+
+export function update(g, columnWidth, height, value) {
+  const digits = splitNumber(value);
+  const data = [digits.thousands, digits.hundreds, digits.tens, digits.ones];
+
+  const columns = g.selectAll('.column').data(data);
+
+  columns
+    .enter()
+    .append('rect')
+    .attr('class', 'column')
+    .merge(columns)
+    .attr('x', (d, i) => i * columnWidth + columnWidth / 4)
+    .attr('width', columnWidth / 2)
+    .attr('y', d => height - (d / 10) * height)
+    .attr('height', d => (d / 10) * height)
+    .attr('fill', '#69b3a2');
+
+  columns.exit().remove();
+}

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,9 @@
+export function splitNumber(num) {
+  const n = Math.max(0, Math.min(9999, parseInt(num, 10) || 0));
+  return {
+    thousands: Math.floor(n / 1000) % 10,
+    hundreds: Math.floor(n / 100) % 10,
+    tens: Math.floor(n / 10) % 10,
+    ones: n % 10
+  };
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,13 @@
+body {
+  font-family: sans-serif;
+  padding: 20px;
+}
+
+#controls {
+  margin-bottom: 10px;
+}
+
+#visualization {
+  border: 1px solid #ccc;
+  padding: 10px;
+}


### PR DESCRIPTION
## Summary
- scaffold basic interface with index.html, css, and JavaScript modules
- visualize a number by splitting into digits and drawing simple columns
- update README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_683ff223dbac832dbb412b4d6e106ef4