### PR TITLE
Use base ten block visuals for tens and hundreds

### DIFF
--- a/js/svgSetup.js
+++ b/js/svgSetup.js
@@ -1,5 +1,5 @@
-const width = 300;
-const height = 200;
+const width = 840;
+const height = 250;
 const margin = { top: 20, right: 20, bottom: 40, left: 20 };
 
 export function createSvg(container) {

--- a/js/updateVisualization.js
+++ b/js/updateVisualization.js
@@ -1,21 +1,101 @@
 import { splitNumber } from './utils.js';
 
+const UNIT = 6; // size of a single unit square in pixels
+const GAP = 2; // gap between blocks
+const HUNDRED_SIZE = UNIT * 10;
+
 export function update(g, columnWidth, height, value) {
   const digits = splitNumber(value);
   const data = [digits.thousands, digits.hundreds, digits.tens, digits.ones];
 
-  const columns = g.selectAll('.column').data(data);
+  const columns = g.selectAll('.column-group').data(data);
+  columns.enter().append('g').attr('class', 'column-group');
+  columns.exit().remove();
 
   columns
-    .enter()
-    .append('rect')
-    .attr('class', 'column')
-    .merge(columns)
-    .attr('x', (d, i) => i * columnWidth + columnWidth / 4)
-    .attr('width', columnWidth / 2)
-    .attr('y', d => height - (d / 10) * height)
-    .attr('height', d => (d / 10) * height)
-    .attr('fill', '#69b3a2');
+    .attr('transform', (d, i) => `translate(${i * columnWidth}, 0)`)
+    .each(function (d, i) {
+      const group = d3.select(this);
+      group.selectAll('*').remove();
 
-  columns.exit().remove();
+      if (i === 0) {
+        // thousands column as simple bar
+        group
+          .append('rect')
+          .attr('x', columnWidth / 4)
+          .attr('width', columnWidth / 2)
+          .attr('y', height - (d / 10) * height)
+          .attr('height', (d / 10) * height)
+          .attr('fill', '#69b3a2');
+        return;
+      }
+
+      if (i === 1) {
+        // hundreds column - 10x10 blocks arranged in a 3x3 grid
+        for (let idx = 0; idx < d; idx++) {
+          const row = Math.floor(idx / 3);
+          const col = idx % 3;
+          const xStart = col * (HUNDRED_SIZE + GAP);
+          const yStart = height - HUNDRED_SIZE - row * (HUNDRED_SIZE + GAP);
+
+          for (let r = 0; r < 10; r++) {
+            for (let c = 0; c < 10; c++) {
+              group
+                .append('rect')
+                .attr('x', xStart + c * UNIT)
+                .attr('y', yStart + r * UNIT)
+                .attr('width', UNIT)
+                .attr('height', UNIT)
+                .attr('fill', '#69b3a2')
+                .attr('stroke', '#fff')
+                .attr('stroke-width', 0.5);
+            }
+          }
+        }
+        return;
+      }
+
+      if (i === 2) {
+        // tens column - rods (1x10 blocks) laid out in two rows
+        for (let idx = 0; idx < d; idx++) {
+          const row = Math.floor(idx / 10);
+          const col = idx % 10;
+          const xStart = col * (UNIT + GAP);
+          const yStart = height - HUNDRED_SIZE - row * (HUNDRED_SIZE + GAP);
+
+          for (let r = 0; r < 10; r++) {
+            group
+              .append('rect')
+              .attr('x', xStart)
+              .attr('y', yStart + r * UNIT)
+              .attr('width', UNIT)
+              .attr('height', UNIT)
+              .attr('fill', '#69b3a2')
+              .attr('stroke', '#fff')
+              .attr('stroke-width', 0.5);
+          }
+        }
+        return;
+      }
+
+      if (i === 3) {
+        // ones column - single squares in two rows
+        for (let idx = 0; idx < d; idx++) {
+          const row = Math.floor(idx / 10);
+          const col = idx % 10;
+          const x = col * (UNIT + GAP);
+          const y = height - UNIT - row * (UNIT + GAP);
+
+          group
+            .append('rect')
+            .attr('x', x)
+            .attr('y', y)
+            .attr('width', UNIT)
+            .attr('height', UNIT)
+            .attr('fill', '#69b3a2')
+            .attr('stroke', '#fff')
+            .attr('stroke-width', 0.5);
+        }
+      }
+    });
 }


### PR DESCRIPTION
## Summary
- expand the SVG size to fit blocks
- draw 10×10 hundred blocks and vertical rods for tens
- keep thousands as a bar chart

## Testing
- `node -e "require('./js/updateVisualization.js')"`

------
https://chatgpt.com/codex/tasks/task_e_683ff54e076c832db15f4a9fce9291e4