### PR TITLE
Remove thousands column and enlarge unit blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 A simple D3 application to visualise regrouping and exchanging.
 
-Open `index.html` in a browser and enter a number (0-9999) to see it represented as columns for thousands, hundreds, tens and ones.
+Open `index.html` in a browser and enter a number (0-999) to see it represented as columns for hundreds, tens and ones.

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <div id="controls">
-    <input id="number-input" type="number" min="0" max="9999" placeholder="Enter number" />
+    <input id="number-input" type="number" min="0" max="999" placeholder="Enter number" />
   </div>
   <div id="visualization"></div>
 </body>

--- a/js/svgSetup.js
+++ b/js/svgSetup.js
@@ -13,7 +13,7 @@ export function createSvg(container) {
     .append('g')
     .attr('transform', `translate(${margin.left}, ${margin.top})`);
 
-  const labels = ['thousands', 'hundreds', 'tens', 'ones'];
+  const labels = ['hundreds','tens','ones'];
   const columnWidth = (width - margin.left - margin.right) / labels.length;
 
   labels.forEach((label, i) => {

--- a/js/updateVisualization.js
+++ b/js/updateVisualization.js
@@ -1,12 +1,12 @@
 import { splitNumber } from './utils.js';
 
-const UNIT = 6; // size of a single unit square in pixels
+const UNIT = 8; // size of a single unit square in pixels
 const GAP = 2; // gap between blocks
 const HUNDRED_SIZE = UNIT * 10;
 
 export function update(g, columnWidth, height, value) {
   const digits = splitNumber(value);
-  const data = [digits.thousands, digits.hundreds, digits.tens, digits.ones];
+  const data = [digits.hundreds, digits.tens, digits.ones];
 
   const columns = g.selectAll('.column-group').data(data);
   columns.enter().append('g').attr('class', 'column-group');
@@ -19,18 +19,6 @@ export function update(g, columnWidth, height, value) {
       group.selectAll('*').remove();
 
       if (i === 0) {
-        // thousands column as simple bar
-        group
-          .append('rect')
-          .attr('x', columnWidth / 4)
-          .attr('width', columnWidth / 2)
-          .attr('y', height - (d / 10) * height)
-          .attr('height', (d / 10) * height)
-          .attr('fill', '#69b3a2');
-        return;
-      }
-
-      if (i === 1) {
         // hundreds column - 10x10 blocks arranged in a 3x3 grid
         for (let idx = 0; idx < d; idx++) {
           const row = Math.floor(idx / 3);
@@ -55,7 +43,7 @@ export function update(g, columnWidth, height, value) {
         return;
       }
 
-      if (i === 2) {
+      if (i === 1) {
         // tens column - rods (1x10 blocks) laid out in two rows
         for (let idx = 0; idx < d; idx++) {
           const row = Math.floor(idx / 10);
@@ -78,7 +66,7 @@ export function update(g, columnWidth, height, value) {
         return;
       }
 
-      if (i === 3) {
+      if (i === 2) {
         // ones column - single squares in two rows
         for (let idx = 0; idx < d; idx++) {
           const row = Math.floor(idx / 10);

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,7 +1,6 @@
 export function splitNumber(num) {
-  const n = Math.max(0, Math.min(9999, parseInt(num, 10) || 0));
+  const n = Math.max(0, Math.min(999, parseInt(num, 10) || 0));
   return {
-    thousands: Math.floor(n / 1000) % 10,
     hundreds: Math.floor(n / 100) % 10,
     tens: Math.floor(n / 10) % 10,
     ones: n % 10


### PR DESCRIPTION
## Summary
- limit input to 0-999
- drop the thousands column
- enlarge unit block size

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_683ffa56ce90832da7139a530deb45da