### PR TITLE
Add simple rendering test using Node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@
 A simple D3 application to visualise regrouping and exchanging.
 
 Open `index.html` in a browser and enter a number (0-9999) to see it represented as columns for thousands, hundreds, tens and ones.
+
+## Running tests
+
+Install dependencies and run the built-in Node test suite:
+
+```bash
+npm install
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "d3_regrouping_exchanging",
+  "version": "1.0.0",
+  "description": "A simple D3 application to visualise regrouping and exchanging.",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "d3": "^7.9.0",
+    "jsdom": "^26.1.0"
+  }
+}

--- a/rendering.test.js
+++ b/rendering.test.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'fs';
+import { JSDOM } from 'jsdom';
+import * as d3 from 'd3';
+import { test } from 'node:test';
+import { createSvg } from './js/svgSetup.js';
+import { update } from './js/updateVisualization.js';
+
+const html = readFileSync('./index.html', 'utf8');
+const dom = new JSDOM(html);
+const { document } = dom.window;
+
+// Provide globals expected by the visualization code
+global.document = document;
+global.d3 = d3;
+
+test('index.html renders SVG', () => {
+  const { g, columnWidth, height } = createSvg('#visualization');
+  const input = document.getElementById('number-input');
+  update(g, columnWidth, height, input.value);
+  const svg = document.querySelector('svg');
+  assert.ok(svg, 'SVG element should exist');
+});


### PR DESCRIPTION
## Summary
- set up Node test framework using node's built‑in runner
- check that an SVG is produced when `index.html` scripts run
- ignore development artifacts
- document how to run the tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683ffbbd2054832db7719dc704844e8a