### PR TITLE
Adjust unit block size and input defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <div id="controls">
-    <input id="number-input" type="number" min="0" max="999" placeholder="Enter number" />
+    <input id="number-input" type="number" min="0" max="999" value="234" placeholder="Enter number" />
   </div>
   <div id="visualization"></div>
 </body>

--- a/js/svgSetup.js
+++ b/js/svgSetup.js
@@ -1,5 +1,5 @@
-const width = 840;
-const height = 250;
+const width = 960;
+const height = 360;
 const margin = { top: 20, right: 20, bottom: 40, left: 20 };
 
 export function createSvg(container) {

--- a/js/updateVisualization.js
+++ b/js/updateVisualization.js
@@ -1,6 +1,6 @@
 import { splitNumber } from './utils.js';
 
-const UNIT = 8; // size of a single unit square in pixels
+const UNIT = 10; // size of a single unit square in pixels
 const GAP = 2; // gap between blocks
 const HUNDRED_SIZE = UNIT * 10;
 


### PR DESCRIPTION
## Summary
- enlarge each square to 10×10px to improve visibility
- expand SVG canvas so new block size fits
- default the input to 234

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684047606994832d818491c42143c583