### PR TITLE
Add regrouping decomposition logic

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,11 +1,18 @@
 import { createSvg } from './svgSetup.js';
 import { update } from './updateVisualization.js';
+import { splitNumber } from './utils.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const { g, columnWidth, height } = createSvg('#visualization');
   const input = document.getElementById('number-input');
-  const updateViz = () => update(g, columnWidth, height, input.value);
+  let digits = splitNumber(input.value);
 
-  input.addEventListener('input', updateViz);
-  updateViz();
+  const render = () => update(g, columnWidth, height, digits);
+
+  input.addEventListener('input', () => {
+    digits = splitNumber(input.value);
+    render();
+  });
+
+  render();
 });

--- a/js/updateVisualization.js
+++ b/js/updateVisualization.js
@@ -1,4 +1,4 @@
-import { splitNumber, digitPhrase, expandedValue } from './utils.js';
+import { splitNumber, digitPhrase, expandedValue, digitsToNumber } from './utils.js';
 
 const UNIT = 10; // size of a single unit square in pixels
 const GAP = 2; // gap between blocks
@@ -6,7 +6,7 @@ const HUNDRED_SIZE = UNIT * 10;
 const TEXT_LINE_HEIGHT = 18;
 
 export function update(g, columnWidth, height, value) {
-  const digits = splitNumber(value);
+  const digits = typeof value === 'object' ? value : splitNumber(value);
   const data = [digits.hundreds, digits.tens, digits.ones];
 
   const columns = g.selectAll('.column-group').data(data);
@@ -51,16 +51,30 @@ export function update(g, columnWidth, height, value) {
       const blockHeight = height - offset;
 
       if (i === 0) {
-        drawHundreds(blocksG, d, blockHeight);
+        drawHundreds(blocksG, d, blockHeight, () => {
+          if (digits.hundreds > 0) {
+            digits.hundreds -= 1;
+            digits.tens += 10;
+            document.getElementById('number-input').value = digitsToNumber(digits);
+            update(g, columnWidth, height, digits);
+          }
+        });
       } else if (i === 1) {
-        drawTens(blocksG, d, blockHeight);
+        drawTens(blocksG, d, blockHeight, () => {
+          if (digits.tens > 0) {
+            digits.tens -= 1;
+            digits.ones += 10;
+            document.getElementById('number-input').value = digitsToNumber(digits);
+            update(g, columnWidth, height, digits);
+          }
+        });
       } else {
         drawOnes(blocksG, d, blockHeight);
       }
     });
 }
 
-function drawHundreds(group, count, height) {
+function drawHundreds(group, count, height, onClick) {
   for (let idx = 0; idx < count; idx++) {
     const row = Math.floor(idx / 3);
     const col = idx % 3;
@@ -77,13 +91,14 @@ function drawHundreds(group, count, height) {
           .attr('height', UNIT)
           .attr('fill', '#69b3a2')
           .attr('stroke', '#fff')
-          .attr('stroke-width', 0.5);
+          .attr('stroke-width', 0.5)
+          .on('click', onClick);
       }
     }
   }
 }
 
-function drawTens(group, count, height) {
+function drawTens(group, count, height, onClick) {
   for (let idx = 0; idx < count; idx++) {
     const row = Math.floor(idx / 10);
     const col = idx % 10;
@@ -99,7 +114,8 @@ function drawTens(group, count, height) {
         .attr('height', UNIT)
         .attr('fill', '#69b3a2')
         .attr('stroke', '#fff')
-        .attr('stroke-width', 0.5);
+        .attr('stroke-width', 0.5)
+        .on('click', onClick);
     }
   }
 }

--- a/js/utils.js
+++ b/js/utils.js
@@ -34,3 +34,7 @@ export function digitPhrase(digit, columnIndex) {
   const plural = digit === 1 ? '' : 's';
   return `${digitToWord(digit)} ${unit}${plural}`;
 }
+
+export function digitsToNumber(d) {
+  return d.hundreds * 100 + d.tens * 10 + d.ones;
+}


### PR DESCRIPTION
## Summary
- add `digitsToNumber` helper
- maintain digit state in main entry
- allow clicking hundreds and tens to break them into smaller units

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684051f42978832da34c0854be115544