### PR TITLE
Add sequential regrouping animations

### DIFF
--- a/js/animations.js
+++ b/js/animations.js
@@ -1,0 +1,68 @@
+import { UNIT, HUNDRED_SIZE, TEXT_LINE_HEIGHT } from './constants.js';
+
+function createSquare(parent) {
+  return parent
+    .append('rect')
+    .attr('width', UNIT)
+    .attr('height', UNIT)
+    .attr('fill', '#69b3a2')
+    .attr('stroke', '#fff')
+    .attr('stroke-width', 0.5);
+}
+
+function createRod(parent) {
+  const g = parent.append('g');
+  for (let r = 0; r < 10; r++) {
+    createSquare(g).attr('y', r * UNIT);
+  }
+  return g;
+}
+
+export function animatePieces(g, count, createFn, start, end, delay = 100, duration = 500) {
+  const layer = g.append('g').attr('class', 'anim-layer');
+  const promises = [];
+  for (let i = 0; i < count; i++) {
+    const piece = createFn(layer).attr('transform', `translate(${start.x},${start.y})`);
+    const t = piece
+      .transition()
+      .delay(i * delay)
+      .duration(duration)
+      .attr('transform', `translate(${end.x},${end.y})`)
+      .on('end', () => piece.remove());
+    promises.push(t.end());
+  }
+  return Promise.all(promises).then(() => layer.remove());
+}
+
+export function centerPosition(columnIndex, columnWidth, height) {
+  const offset = TEXT_LINE_HEIGHT * 3 + 5;
+  const blockHeight = height - offset;
+  return {
+    x: columnIndex * columnWidth + columnWidth / 2 - UNIT / 2,
+    y: offset + blockHeight / 2 - UNIT * 5,
+  };
+}
+
+export function animateHundredToTens(g, columnWidth, height) {
+  const start = centerPosition(0, columnWidth, height);
+  const end = centerPosition(1, columnWidth, height);
+  return animatePieces(g, 10, createRod, start, end);
+}
+
+export function animateTensToOnes(g, columnWidth, height) {
+  const start = centerPosition(1, columnWidth, height);
+  const end = centerPosition(2, columnWidth, height);
+  return animatePieces(g, 10, createSquare, start, end);
+}
+
+export function animateTensToHundred(g, columnWidth, height) {
+  const start = centerPosition(1, columnWidth, height);
+  const end = centerPosition(0, columnWidth, height);
+  return animatePieces(g, 10, createRod, start, end);
+}
+
+export function animateOnesToTens(g, columnWidth, height) {
+  const start = centerPosition(2, columnWidth, height);
+  const end = centerPosition(1, columnWidth, height);
+  return animatePieces(g, 10, createSquare, start, end);
+}

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,0 +1,4 @@
+export const UNIT = 10; // size of a single unit square in pixels
+export const GAP = 2; // gap between blocks
+export const HUNDRED_SIZE = UNIT * 10;
+export const TEXT_LINE_HEIGHT = 18;

--- a/js/updateVisualization.js
+++ b/js/updateVisualization.js
@@ -1,9 +1,11 @@
 import { splitNumber, digitPhrase, expandedValue, digitsToNumber } from './utils.js';
-
-const UNIT = 10; // size of a single unit square in pixels
-const GAP = 2; // gap between blocks
-const HUNDRED_SIZE = UNIT * 10;
-const TEXT_LINE_HEIGHT = 18;
+import { UNIT, GAP, HUNDRED_SIZE, TEXT_LINE_HEIGHT } from './constants.js';
+import {
+  animateHundredToTens,
+  animateTensToOnes,
+  animateTensToHundred,
+  animateOnesToTens,
+} from './animations.js';
 
 export function update(g, columnWidth, height, value) {
   const digits = typeof value === 'object' ? value : splitNumber(value);
@@ -51,8 +53,9 @@ export function update(g, columnWidth, height, value) {
       const blockHeight = height - offset;
 
       if (i === 0) {
-        drawHundreds(blocksG, d, blockHeight, () => {
+        drawHundreds(blocksG, d, blockHeight, async () => {
           if (digits.hundreds > 0) {
+            await animateHundredToTens(g, columnWidth, height);
             digits.hundreds -= 1;
             digits.tens += 10;
             document.getElementById('number-input').value = digitsToNumber(digits);
@@ -64,16 +67,18 @@ export function update(g, columnWidth, height, value) {
           blocksG,
           d,
           blockHeight,
-          () => {
+          async () => {
             if (digits.tens > 0) {
+              await animateTensToOnes(g, columnWidth, height);
               digits.tens -= 1;
               digits.ones += 10;
               document.getElementById('number-input').value = digitsToNumber(digits);
               update(g, columnWidth, height, digits);
             }
           },
-          () => {
+          async () => {
             if (digits.tens >= 10) {
+              await animateTensToHundred(g, columnWidth, height);
               digits.tens -= 10;
               digits.hundreds += 1;
               document.getElementById('number-input').value = digitsToNumber(digits);
@@ -82,8 +87,9 @@ export function update(g, columnWidth, height, value) {
           }
         );
       } else {
-        drawOnes(blocksG, d, blockHeight, () => {
+        drawOnes(blocksG, d, blockHeight, async () => {
           if (digits.ones >= 10) {
+            await animateOnesToTens(g, columnWidth, height);
             digits.ones -= 10;
             digits.tens += 1;
             document.getElementById('number-input').value = digitsToNumber(digits);


### PR DESCRIPTION
## Summary
- centralize drawing constants in `constants.js`
- add `animations.js` for sequential movement helpers
- trigger animations in `updateVisualization`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684063caae68832dbb11450985643249