### PR TITLE
Refine animation start/end positions

### DIFF
--- a/js/layout.js
+++ b/js/layout.js
@@ -1,0 +1,33 @@
+import { UNIT, HUNDRED_SIZE, GAP, TEXT_LINE_HEIGHT } from './constants.js';
+
+function columnOffset() {
+  return TEXT_LINE_HEIGHT * 3 + 5;
+}
+
+function blockHeight(height) {
+  return height - columnOffset();
+}
+
+export function hundredPosition(index, columnWidth, height, columnIndex = 0) {
+  const row = Math.floor(index / 3);
+  const col = index % 3;
+  const x = columnIndex * columnWidth + col * (HUNDRED_SIZE + GAP);
+  const y = blockHeight(height) - HUNDRED_SIZE - row * (HUNDRED_SIZE + GAP);
+  return { x, y: columnOffset() + y };
+}
+
+export function tenPosition(index, columnWidth, height, columnIndex = 1) {
+  const row = Math.floor(index / 10);
+  const col = index % 10;
+  const x = columnIndex * columnWidth + col * (UNIT + GAP);
+  const y = blockHeight(height) - HUNDRED_SIZE - row * (HUNDRED_SIZE + GAP);
+  return { x, y: columnOffset() + y };
+}
+
+export function onePosition(index, columnWidth, height, columnIndex = 2) {
+  const row = Math.floor(index / 10);
+  const col = index % 10;
+  const x = columnIndex * columnWidth + col * (UNIT + GAP);
+  const y = blockHeight(height) - UNIT - row * (UNIT + GAP);
+  return { x, y: columnOffset() + y };
+}

--- a/js/updateVisualization.js
+++ b/js/updateVisualization.js
@@ -55,7 +55,13 @@ export function update(g, columnWidth, height, value) {
       if (i === 0) {
         drawHundreds(blocksG, d, blockHeight, async () => {
           if (digits.hundreds > 0) {
-            await animateHundredToTens(g, columnWidth, height);
+            await animateHundredToTens(
+              g,
+              columnWidth,
+              height,
+              digits.hundreds,
+              digits.tens
+            );
             digits.hundreds -= 1;
             digits.tens += 10;
             document.getElementById('number-input').value = digitsToNumber(digits);
@@ -69,7 +75,13 @@ export function update(g, columnWidth, height, value) {
           blockHeight,
           async () => {
             if (digits.tens > 0) {
-              await animateTensToOnes(g, columnWidth, height);
+              await animateTensToOnes(
+                g,
+                columnWidth,
+                height,
+                digits.tens,
+                digits.ones
+              );
               digits.tens -= 1;
               digits.ones += 10;
               document.getElementById('number-input').value = digitsToNumber(digits);
@@ -78,7 +90,13 @@ export function update(g, columnWidth, height, value) {
           },
           async () => {
             if (digits.tens >= 10) {
-              await animateTensToHundred(g, columnWidth, height);
+              await animateTensToHundred(
+                g,
+                columnWidth,
+                height,
+                digits.tens,
+                digits.hundreds
+              );
               digits.tens -= 10;
               digits.hundreds += 1;
               document.getElementById('number-input').value = digitsToNumber(digits);
@@ -89,7 +107,13 @@ export function update(g, columnWidth, height, value) {
       } else {
         drawOnes(blocksG, d, blockHeight, async () => {
           if (digits.ones >= 10) {
-            await animateOnesToTens(g, columnWidth, height);
+            await animateOnesToTens(
+              g,
+              columnWidth,
+              height,
+              digits.ones,
+              digits.tens
+            );
             digits.ones -= 10;
             digits.tens += 1;
             document.getElementById('number-input').value = digitsToNumber(digits);


### PR DESCRIPTION
## Summary
- add layout helpers to calculate block positions
- animate each square/rod from its current position to final destination
- pass digit counts to animation helpers

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684071e24484832dbfe84758a204dd00