### PR TITLE
Fix lingering blocks during regrouping animations

### DIFF
--- a/js/animations.js
+++ b/js/animations.js
@@ -74,7 +74,19 @@ export function animateTensToOnes(g, columnWidth, height, tensCount, onesCount, 
   return animatePieces(g, 10, createSquare, startPositions, endPositions);
 }
 
-export function animateTensToHundred(g, columnWidth, height, tensCount, hundredsCount) {
+export function animateTensToHundred(
+  g,
+  columnWidth,
+  height,
+  tensCount,
+  hundredsCount,
+  blocksG
+) {
+  if (blocksG) {
+    for (let i = tensCount - 10; i < tensCount; i++) {
+      blocksG.select(`g.ten-rod[data-index="${i}"]`).remove();
+    }
+  }
   const startPositions = Array.from({ length: 10 }, (_, i) =>
     tenPosition(tensCount - 10 + i, columnWidth, height)
   );
@@ -86,7 +98,19 @@ export function animateTensToHundred(g, columnWidth, height, tensCount, hundreds
   return animatePieces(g, 10, createRod, startPositions, endPositions);
 }
 
-export function animateOnesToTens(g, columnWidth, height, onesCount, tensCount) {
+export function animateOnesToTens(
+  g,
+  columnWidth,
+  height,
+  onesCount,
+  tensCount,
+  blocksG
+) {
+  if (blocksG) {
+    for (let i = onesCount - 10; i < onesCount; i++) {
+      blocksG.select(`rect[data-index="${i}"]`).remove();
+    }
+  }
   const startPositions = Array.from({ length: 10 }, (_, i) =>
     onePosition(onesCount - 10 + i, columnWidth, height)
   );

--- a/js/updateVisualization.js
+++ b/js/updateVisualization.js
@@ -99,7 +99,8 @@ export function update(g, columnWidth, height, value) {
                 columnWidth,
                 height,
                 digits.tens,
-                digits.hundreds
+                digits.hundreds,
+                blocksG
               );
               digits.tens -= 10;
               digits.hundreds += 1;
@@ -117,7 +118,8 @@ export function update(g, columnWidth, height, value) {
               columnWidth,
               height,
               digits.ones,
-              digits.tens
+              digits.tens,
+              blocksG
             );
             digits.ones -= 10;
             digits.tens += 1;
@@ -199,6 +201,7 @@ function drawOnes(group, count, height, onRightClick) {
 
     group
       .append('rect')
+      .attr('data-index', idx)
       .attr('x', x)
       .attr('y', y)
       .attr('width', UNIT)


### PR DESCRIPTION
## Summary
- remove rods/squares from their original column before starting animations
- allow `animateTensToHundred` and `animateOnesToTens` to remove DOM elements
- tag ones with `data-index` so they can be removed
- update calls in `updateVisualization` to pass the new block groups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68409f4aa744832d9a8c2845606db8df