### PR TITLE
Initialize visualization immediately

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2,17 +2,21 @@ import { createSvg } from './svgSetup.js';
 import { update } from './updateVisualization.js';
 import { splitNumber } from './utils.js';
 
-document.addEventListener('DOMContentLoaded', () => {
-  const { g, columnWidth, height } = createSvg('#visualization');
-  const input = document.getElementById('number-input');
-  let digits = splitNumber(input.value);
+// The script tag in index.html uses the `module` type which loads after the DOM
+// is parsed. That means we can safely run our initialization code immediately
+// without waiting for the `DOMContentLoaded` event. This ensures the initial
+// visualization appears as soon as the page is loaded.
 
-  const render = () => update(g, columnWidth, height, digits);
+const { g, columnWidth, height } = createSvg('#visualization');
+const input = document.getElementById('number-input');
+let digits = splitNumber(input.value);
 
-  input.addEventListener('input', () => {
-    digits = splitNumber(input.value);
-    render();
-  });
+const render = () => update(g, columnWidth, height, digits);
 
+input.addEventListener('input', () => {
+  digits = splitNumber(input.value);
   render();
 });
+
+// Render once on start so the user immediately sees the visualization.
+render();


### PR DESCRIPTION
## Summary
- render the visualization as soon as the module loads instead of waiting for a DOMContentLoaded handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840a1aa8fc0832d89a564c9b32c1d4e