### PR TITLE
Add column spacing visuals

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -2,3 +2,4 @@ export const UNIT = 10; // size of a single unit square in pixels
 export const GAP = 2; // gap between blocks
 export const HUNDRED_SIZE = UNIT * 10;
 export const TEXT_LINE_HEIGHT = 18;
+export const COLUMN_GAP = 20; // space between columns

--- a/js/layout.js
+++ b/js/layout.js
@@ -1,4 +1,4 @@
-import { UNIT, HUNDRED_SIZE, GAP, TEXT_LINE_HEIGHT } from './constants.js';
+import { UNIT, HUNDRED_SIZE, GAP, TEXT_LINE_HEIGHT, COLUMN_GAP } from './constants.js';
 
 function columnOffset() {
   return TEXT_LINE_HEIGHT * 3 + 5;
@@ -11,7 +11,7 @@ function blockHeight(height) {
 export function hundredPosition(index, columnWidth, height, columnIndex = 0) {
   const row = Math.floor(index / 3);
   const col = index % 3;
-  const x = columnIndex * columnWidth + col * (HUNDRED_SIZE + GAP);
+  const x = columnIndex * (columnWidth + COLUMN_GAP) + col * (HUNDRED_SIZE + GAP);
   const y = blockHeight(height) - HUNDRED_SIZE - row * (HUNDRED_SIZE + GAP);
   return { x, y: columnOffset() + y };
 }
@@ -19,7 +19,7 @@ export function hundredPosition(index, columnWidth, height, columnIndex = 0) {
 export function tenPosition(index, columnWidth, height, columnIndex = 1) {
   const row = Math.floor(index / 10);
   const col = index % 10;
-  const x = columnIndex * columnWidth + col * (UNIT + GAP);
+  const x = columnIndex * (columnWidth + COLUMN_GAP) + col * (UNIT + GAP);
   const y = blockHeight(height) - HUNDRED_SIZE - row * (HUNDRED_SIZE + GAP);
   return { x, y: columnOffset() + y };
 }
@@ -27,7 +27,7 @@ export function tenPosition(index, columnWidth, height, columnIndex = 1) {
 export function onePosition(index, columnWidth, height, columnIndex = 2) {
   const row = Math.floor(index / 10);
   const col = index % 10;
-  const x = columnIndex * columnWidth + col * (UNIT + GAP);
+  const x = columnIndex * (columnWidth + COLUMN_GAP) + col * (UNIT + GAP);
   const y = blockHeight(height) - UNIT - row * (UNIT + GAP);
   return { x, y: columnOffset() + y };
 }

--- a/js/svgSetup.js
+++ b/js/svgSetup.js
@@ -1,3 +1,5 @@
+import { COLUMN_GAP } from './constants.js';
+
 const width = 960;
 const height = 360;
 const margin = { top: 20, right: 20, bottom: 40, left: 20 };
@@ -13,11 +15,24 @@ export function createSvg(container) {
     .append('g')
     .attr('transform', `translate(${margin.left}, ${margin.top})`);
 
-  const labels = ['hundreds','tens','ones'];
-  const columnWidth = (width - margin.left - margin.right) / labels.length;
+  const labels = ['hundreds', 'tens', 'ones'];
+  const columnWidth =
+    (width - margin.left - margin.right - COLUMN_GAP * (labels.length - 1)) /
+    labels.length;
+
+  const bg = g.append('g').attr('class', 'column-backgrounds');
 
   labels.forEach((label, i) => {
-    const x = i * columnWidth;
+    const x = i * (columnWidth + COLUMN_GAP);
+    bg
+      .append('rect')
+      .attr('x', x)
+      .attr('y', 0)
+      .attr('width', columnWidth)
+      .attr('height', height - margin.bottom)
+      .attr('fill', '#f5f5f5')
+      .attr('stroke', '#ddd');
+
     g.append('text')
       .attr('x', x + columnWidth / 2)
       .attr('y', height - margin.bottom + 15)

--- a/js/updateVisualization.js
+++ b/js/updateVisualization.js
@@ -1,5 +1,5 @@
 import { splitNumber, digitPhrase, expandedValue, digitsToNumber } from './utils.js';
-import { UNIT, GAP, HUNDRED_SIZE, TEXT_LINE_HEIGHT } from './constants.js';
+import { UNIT, GAP, HUNDRED_SIZE, TEXT_LINE_HEIGHT, COLUMN_GAP } from './constants.js';
 import {
   animateHundredToTens,
   animateTensToOnes,
@@ -18,7 +18,7 @@ export function update(g, columnWidth, height, value) {
   columns.exit().remove();
 
   columns
-    .attr('transform', (d, i) => `translate(${i * columnWidth}, 0)`)
+    .attr('transform', (d, i) => `translate(${i * (columnWidth + COLUMN_GAP)}, 0)`)
     .each(function (d, i) {
       const group = d3.select(this);
       const textG = group.select('.value-text');


### PR DESCRIPTION
## Summary
- add `COLUMN_GAP` constant for extra space between columns
- draw subtle background rectangles for each column
- update layout helpers and animations to respect the new gap
- shift column groups using the gap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840a1946790832da7fb40656a11211f