### PR TITLE
Fix initial render issue

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2,21 +2,21 @@ import { createSvg } from './svgSetup.js';
 import { update } from './updateVisualization.js';
 import { splitNumber } from './utils.js';
 
-// The script tag in index.html uses the `module` type which loads after the DOM
-// is parsed. That means we can safely run our initialization code immediately
-// without waiting for the `DOMContentLoaded` event. This ensures the initial
-// visualization appears as soon as the page is loaded.
+// Some browsers can execute module scripts before the DOM is fully parsed even
+// with the `defer` attribute.  To guarantee the elements exist when we build the
+// SVG, wait for `DOMContentLoaded` before initialising the visualisation.
+document.addEventListener('DOMContentLoaded', () => {
+  const { g, columnWidth, height } = createSvg('#visualization');
+  const input = document.getElementById('number-input');
+  let digits = splitNumber(input.value);
 
-const { g, columnWidth, height } = createSvg('#visualization');
-const input = document.getElementById('number-input');
-let digits = splitNumber(input.value);
+  const render = () => update(g, columnWidth, height, digits);
 
-const render = () => update(g, columnWidth, height, digits);
+  input.addEventListener('input', () => {
+    digits = splitNumber(input.value);
+    render();
+  });
 
-input.addEventListener('input', () => {
-  digits = splitNumber(input.value);
+  // Render once on start so the user immediately sees the visualization.
   render();
 });
-
-// Render once on start so the user immediately sees the visualization.
-render();


### PR DESCRIPTION
## Summary
- initialize the SVG after DOMContentLoaded so the visualisation is drawn immediately

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843f8195da4832dbe757d8760456bc0